### PR TITLE
Added note to install legacy-cgi 

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -50,7 +50,8 @@ password 'grok', you should be able to add the grok-based applications
 (such as grokwiki) from the menu.
 
 If you are using python >3.13 and encounter a ``No module named 'cgi'`` error, install the legacy cgi package:
-``./bin/pip install legacy-cgi``
+
+    $ ./bin/pip install legacy-cgi
 
 Running the tests
 -----------------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -49,9 +49,10 @@ If you now connect to port 8080 and log in with username 'grok',
 password 'grok', you should be able to add the grok-based applications
 (such as grokwiki) from the menu.
 
-If you are using python >3.13 and encounter a ``No module named 'cgi'`` error, install the legacy cgi package:
+If you are using python >= 3.13 and encounter a ``No module named 'cgi'``
+error, install the legacy cgi package:
 
-    $ ./bin/pip install legacy-cgi
+    $ bin/pip install legacy-cgi
 
 Running the tests
 -----------------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -49,6 +49,9 @@ If you now connect to port 8080 and log in with username 'grok',
 password 'grok', you should be able to add the grok-based applications
 (such as grokwiki) from the menu.
 
+If you are using python >3.13 and encounter a ``No module named 'cgi'`` error, install the legacy cgi package:
+``./bin/pip install legacy-cgi``
+
 Running the tests
 -----------------
 


### PR DESCRIPTION
Adding a note to install legacy-cgi package when using python >3.13