### PR TITLE
Re-enable `zpassword` in `buildout.cfg`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Grok changes
 
 - Make ``grokwiki`` example project work again.
 
+- Re-enable ``zpassword`` in ``buildout.cfg``.
+
 
 5.1 (2024-10-28)
 ================

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -9,6 +9,7 @@ parts =
   site_zcml
   deploy_ini
   debug_ini
+  zpasswd
 develop =
   .
   grokwiki
@@ -65,11 +66,8 @@ recipe = collective.recipe.template
 input = etc/debug.ini.in
 output = ${buildout:parts-directory}/etc/debug.ini
 
-# python3 port: disabled.
-# This section is named so that the zpasswd utility is
-# called `zpasswd`
 [zpasswd]
-recipe = z3c.recipe.dev:script
+recipe = zc.recipe.egg
 eggs = grokwiki
-module = zope.app.server.zpasswd
-method = main
+       zope.password
+scripts = zpasswd


### PR DESCRIPTION
This a followup of https://github.com/zopefoundation/zope.app.server/issues/10